### PR TITLE
Support building as a modular framework

### DIFF
--- a/Classes/MRDatabaseContentChecker.h
+++ b/Classes/MRDatabaseContentChecker.h
@@ -14,8 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import <FMDatabase.h>
-#import <FMDatabaseQueue.h>
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDatabaseQueue.h>
 
 
 /**


### PR DESCRIPTION
Use name spacing for FMDB header files to support building as a framework via Cocoapods.
